### PR TITLE
Bumps version to 6.0.27 Release Candidate

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -4,7 +4,7 @@
 # Installs the Uni-Fi controller software on a FreeBSD machine (presumably running pfSense).
 
 # The latest version of UniFi:
-UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/6.0.26-dfb550c0bf/UniFi.unix.zip"
+UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/6.0.27-e23884806a/UniFi.unix.zip"
 
 # The rc script associated with this branch or fork:
 RC_SCRIPT_URL="https://raw.githubusercontent.com/gozoinks/unifi-pfsense/master/rc.d/unifi.sh"


### PR DESCRIPTION
Bumps version to 6.0.27 Release Candidate, keep in mind Release Candidates are not classified as stable releases. Cannot downgrade from 6.1.16 without a full uninstall of Unifi... This did install clean on a fresh virtual machine running on:

PFSense 2.4.5
FreeBSD 11.3-STABLE

Link to Ubiquiti's forum about the release:

https://community.ui.com/releases/UniFi-Network-Controller-6-0-27/452aa4a3-c108-4a04-8c05-242371c27d93

Install link:

fetch -o - https://git.io/JUhf1 | sh -s

Install link with text output (If you do decide to install it, and feel like sharing your Bash results, please upload the text file)

fetch -o - https://git.io/JUhf1 | sh -s cmd |& tee unifi6027.txt